### PR TITLE
remove quoted variable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ No requirements.
 
 ## Contributing
 
-This module accepting or open for any contributions from anyone, please see the [CONTRIBUTING.md](https://github.com/traveloka/terraform-aws-private-route53-zone/blob/master/CONTRIBUTING.md) for more detail about how to contribute to this module.
+This module accepting or open for any contributions from anyone, please see the [CONTRIBUTING.md](https://github.com/traveloka/terraform-aws-kms/blob/master/CONTRIBUTING.md) for more detail about how to contribute to this module.
 
 ## License
 
-This module is under Apache License 2.0 - see the [LICENSE](https://github.com/traveloka/terraform-aws-private-route53-zone/blob/master/LICENSE) file for details.
+This module is under Apache License 2.0 - see the [LICENSE](https://github.com/traveloka/terraform-aws-kms/blob/master/LICENSE) file for details.

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "product_domain" {
 }
 
 variable "additional_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Additional tags to be added to kms-cmk"
   default     = {}
 }


### PR DESCRIPTION
### Description

To fix:
```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/lambda_tvlk_secret/variables.tf line 34, in variable "additional_tags":
  34:   type        = "map"
```
